### PR TITLE
fix: use getDataPath in tests and components for GitHub Pages

### DIFF
--- a/src/components/BuildingCostView/__tests__/BuildingCostView.test.tsx
+++ b/src/components/BuildingCostView/__tests__/BuildingCostView.test.tsx
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { getDataPath } from '../../../utils/paths';
 import { render, screen } from '@testing-library/react';
 import { BuildingCostView } from '../index';
 import type { CalculationResult } from '../../../types/calculation';
@@ -60,7 +61,7 @@ describe('BuildingCostView', () => {
           gridPos: 0,
           speed: 0.75,
           prefabId: 2303,
-          iconPath: '/data/Machines/Icons/2303.png',
+            iconPath: getDataPath('data/Machines/Icons/2303.png'),
         },
       ],
       [
@@ -73,7 +74,7 @@ describe('BuildingCostView', () => {
           gridPos: 0,
           speed: 1.0,
           prefabId: 2304,
-          iconPath: '/data/Machines/Icons/2304.png',
+            iconPath: getDataPath('data/Machines/Icons/2304.png'),
         },
       ],
     ]),

--- a/src/components/ItemIcon.tsx
+++ b/src/components/ItemIcon.tsx
@@ -1,3 +1,5 @@
+import { getDataPath } from '../utils/paths';
+
 interface ItemIconProps {
   itemId: number;
   size?: number;
@@ -6,9 +8,9 @@ interface ItemIconProps {
 }
 
 export function ItemIcon({ itemId, size = 32, className = '', alt = '' }: ItemIconProps) {
-  // Try Items folder first, then Machines folder
-  const itemIconPath = `/data/Items/Icons/${itemId}.png`;
-  const machineIconPath = `/data/Machines/Icons/${itemId}.png`;
+  // Try Items folder first, then Machines folder (use getDataPath to handle base path)
+  const itemIconPath = getDataPath(`data/Items/Icons/${itemId}.png`);
+  const machineIconPath = getDataPath(`data/Machines/Icons/${itemId}.png`);
   
   return (
     <picture>

--- a/src/components/RecipeSelector/index.tsx
+++ b/src/components/RecipeSelector/index.tsx
@@ -1,4 +1,5 @@
 import { useState, useMemo } from 'react';
+import { getDataPath } from '../../utils/paths';
 import { useTranslation } from 'react-i18next';
 import * as Tabs from '@radix-ui/react-tabs';
 import type { Recipe } from '../../types';
@@ -104,13 +105,13 @@ export function RecipeSelector({ recipes, onRecipeSelect, selectedRecipeId }: Re
     if (category === 'all') return { label: t('categoryAll') };
     
     const categoryIconMap: Record<string, { icon: string; label: string }> = {
-      'Smelt': { icon: '/data/Machines/Icons/2302.png', label: t('categorySmelt') },
-      'Assemble': { icon: '/data/Machines/Icons/2303.png', label: t('categoryAssemble') },
-      'Chemical': { icon: '/data/Machines/Icons/2309.png', label: t('categoryChemical') },
-      'Research': { icon: '/data/Machines/Icons/2901.png', label: t('categoryResearch') },
-      'Refine': { icon: '/data/Machines/Icons/2308.png', label: t('categoryRefine') },
-      'Particle': { icon: '/data/Machines/Icons/2310.png', label: t('categoryParticle') },
-      'Fractionate': { icon: '/data/Machines/Icons/2314.png', label: t('categoryFractionate') },
+      'Smelt': { icon: getDataPath('data/Machines/Icons/2302.png'), label: t('categorySmelt') },
+      'Assemble': { icon: getDataPath('data/Machines/Icons/2303.png'), label: t('categoryAssemble') },
+      'Chemical': { icon: getDataPath('data/Machines/Icons/2309.png'), label: t('categoryChemical') },
+      'Research': { icon: getDataPath('data/Machines/Icons/2901.png'), label: t('categoryResearch') },
+      'Refine': { icon: getDataPath('data/Machines/Icons/2308.png'), label: t('categoryRefine') },
+      'Particle': { icon: getDataPath('data/Machines/Icons/2310.png'), label: t('categoryParticle') },
+      'Fractionate': { icon: getDataPath('data/Machines/Icons/2314.png'), label: t('categoryFractionate') },
     };
     
     return categoryIconMap[category] || { label: category };

--- a/src/components/ResultTree/__tests__/ResultTree.test.tsx
+++ b/src/components/ResultTree/__tests__/ResultTree.test.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { getDataPath } from '../../../utils/paths';
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { render, screen, fireEvent, cleanup } from '@testing-library/react';
 import { ProductionTree } from '../index';
@@ -93,14 +94,22 @@ describe('ProductionTree', () => {
             productive: true,
         },
         machine: {
+            id: 2301,
             name: 'Arc Smelter',
+            count: 1,
+            Type: 'Smelt',
+            isRaw: false,
             assemblerSpeed: 10000,
             workEnergyPerTick: 120,
+            idleEnergyPerTick: 0,
+            exchangeEnergyPerTick: 0,
+            isPowerConsumer: true,
+            isPowerExchanger: false,
         },
         machineCount: 1,
         targetOutputRate: 60,
         power: { total: 120, machines: 120, sorters: 0 },
-        conveyorBelts: { inputs: 1, outputs: 1, total: 2, saturation: 85, bottleneckType: 'input' },
+    conveyorBelts: { inputs: 1, outputs: 1, total: 2, saturation: 85, bottleneckType: 'input' as const },
         proliferator: { type: 'none' as const, mode: 'speed' as const, productionBonus: 0, speedBonus: 0, powerIncrease: 0 },
         inputs: [
             { itemId: 1001, itemName: 'Iron Ore', requiredRate: 60 },
@@ -168,7 +177,7 @@ describe('ProductionTree', () => {
             conveyorBelts: { 
                 ...mockRecipeNode.conveyorBelts, 
                 saturation: 85, 
-                bottleneckType: 'input' 
+                bottleneckType: 'input' as const 
             },
         };
         
@@ -283,17 +292,17 @@ describe('ProductionTree', () => {
         
         render(<ProductionTree node={explicitRecipeNode} />);
         
-        // Explicit=trueの場合、/data/Recipes/Icons/120.png が使用される
-        const img = screen.getByAltText('Plasma Refining') as HTMLImageElement;
-        expect(img.src).toContain('/data/Recipes/Icons/120.png');
+    // Explicit=trueの場合、recipes固有のアイコンが使用される
+    const img = screen.getByAltText('Plasma Refining') as HTMLImageElement;
+    expect(img.src).toContain(getDataPath('data/Recipes/Icons/120.png'));
     });
 
     it('非Explicitレシピの場合、結果アイテムのアイコンが表示される', () => {
         render(<ProductionTree node={mockRecipeNode} />);
         
-        // Explicit=falseの場合、/data/Items/Icons/1002.png が使用される
-        const img = screen.getByAltText('Iron Ingot') as HTMLImageElement;
-        expect(img.src).toContain('/data/Items/Icons/1002.png');
+    // Explicit=falseの場合、結果アイテムのアイコンが使用される
+    const img = screen.getByAltText('Iron Ingot') as HTMLImageElement;
+    expect(img.src).toContain(getDataPath('data/Items/Icons/1002.png'));
     });
 
     it('循環依存ノードの場合、特別なスタイルとアイコンが表示される', () => {

--- a/src/components/__tests__/ItemIcon.test.tsx
+++ b/src/components/__tests__/ItemIcon.test.tsx
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import { ItemIcon } from '../ItemIcon';
+import { getDataPath } from '../../utils/paths';
 
 describe('ItemIcon', () => {
   it('正しいitemIdでアイコンをレンダリングできる', () => {
@@ -34,15 +35,15 @@ describe('ItemIcon', () => {
     const picture = screen.getByAltText('Iron Ore').parentElement;
     const source = picture?.querySelector('source');
     
-    expect(source).toBeInTheDocument();
-    expect(source).toHaveAttribute('srcset', '/data/Items/Icons/1001.png');
+  expect(source).toBeInTheDocument();
+  expect(source).toHaveAttribute('srcset', getDataPath('data/Items/Icons/1001.png'));
   });
 
   it('フォールバックパスを設定する（Machines folder）', () => {
     render(<ItemIcon itemId={2001} alt="Assembler" />);
     
     const img = screen.getByAltText('Assembler');
-    expect(img).toHaveAttribute('src', '/data/Machines/Icons/2001.png');
+  expect(img).toHaveAttribute('src', getDataPath('data/Machines/Icons/2001.png'));
   });
 
   it('エラー時にフォールバック処理が動作する', () => {
@@ -57,7 +58,7 @@ describe('ItemIcon', () => {
     img.dispatchEvent(event);
     
     // 初期状態では機械フォルダのパスが設定されている
-    expect(img.src).toContain('/data/Machines/Icons/9999.png');
+  expect(img.src).toContain(getDataPath('data/Machines/Icons/9999.png'));
   });
 
   it('altテキストが空の場合でもレンダリングできる', () => {

--- a/src/utils/__tests__/grid.test.ts
+++ b/src/utils/__tests__/grid.test.ts
@@ -6,6 +6,7 @@ import {
   getItemIconPath,
   getMachineIconPath,
 } from '../grid';
+import { getDataPath } from '../../utils/paths';
 import type { GridPosition } from '../../types';
 
 describe('grid', () => {
@@ -103,14 +104,14 @@ describe('grid', () => {
     it('Explicit=trueの場合、レシピIDでアイコンパスを取得', () => {
       const path = getRecipeIconPath(1001, true);
 
-      // BASE_URLが含まれるパスになる
-      expect(path).toContain('data/Recipes/Icons/1001.png');
+  // BASE_URLが含まれるパスになる
+  expect(path).toContain(getDataPath('data/Recipes/Icons/1001.png'));
     });
 
     it('Explicit=falseかつfirstResultIdありの場合、アイテムアイコンパスを取得', () => {
       const path = getRecipeIconPath(1001, false, 2001);
 
-      expect(path).toContain('data/Items/Icons/2001.png');
+  expect(path).toContain(getDataPath('data/Items/Icons/2001.png'));
     });
 
     it('Explicit=falseかつfirstResultIdなしの場合、空文字列を返す', () => {
@@ -124,13 +125,13 @@ describe('grid', () => {
     it('アイテムIDからアイコンパスを生成する', () => {
       const path = getItemIconPath(1101);
 
-      expect(path).toContain('data/Items/Icons/1101.png');
+  expect(path).toContain(getDataPath('data/Items/Icons/1101.png'));
     });
 
     it('異なるアイテムIDでも正しく動作する', () => {
       const path = getItemIconPath(9999);
 
-      expect(path).toContain('data/Items/Icons/9999.png');
+  expect(path).toContain(getDataPath('data/Items/Icons/9999.png'));
     });
   });
 
@@ -138,13 +139,13 @@ describe('grid', () => {
     it('機械IDからアイコンパスを生成する', () => {
       const path = getMachineIconPath(2303);
 
-      expect(path).toContain('data/Machines/Icons/2303.png');
+  expect(path).toContain(getDataPath('data/Machines/Icons/2303.png'));
     });
 
     it('異なる機械IDでも正しく動作する', () => {
       const path = getMachineIconPath(5555);
 
-      expect(path).toContain('data/Machines/Icons/5555.png');
+  expect(path).toContain(getDataPath('data/Machines/Icons/5555.png'));
     });
   });
 });


### PR DESCRIPTION
Replace hard-coded /data/... asset paths with getDataPath(...) in components and tests to fix GitHub Pages subpath asset loading. Includes test updates and small type-fix in ResultTree tests.

This PR ensures assets are loaded relative to the app base path and prevents 404/429 errors when deployed under a subpath.