### PR TITLE
refactor: 型安全なストレージシリアライザーを導入

### DIFF
--- a/.cursor/rules/coding.mdc
+++ b/.cursor/rules/coding.mdc
@@ -230,11 +230,45 @@ function createNode(id: string, options?: NodeOptions)
 - `package.json`、`tsconfig.json`、`vite.config.ts` などの変更は必ず理由を説明
 - ビルド設定の変更は影響範囲を確認してから実施
 
-### 将来的な拡張性の考慮を禁じる
+### 将来的な拡張性の考慮を禁じる（YAGNI 原則）
 
-- YAGNI原則: 必要になってから実装する
-- 「将来使うかもしれない」機能の実装を禁止
-- 過剰な抽象化を避ける
+**YAGNI (You Aren't Gonna Need It)**: 必要になってから実装する
+
+#### 禁止事項
+
+- ❌ 「将来使うかもしれない」機能の実装
+- ❌ 1箇所でしか使われていない共通化
+- ❌ 型安全性を犠牲にした汎用化
+- ❌ 「拡張性のため」のインターフェース追加
+
+#### 汎用化のタイミング
+
+- **1箇所**: 汎用化しない（特化した実装）
+- **2箇所**: まだ汎用化しない（WET > DRY）
+- **3箇所**: 汎用化を検討する（パターンが明確になってから）
+
+#### 具体例
+
+```typescript
+// ❌ 悪い例: 1箇所でしか使わない汎用ユーティリティ
+function getNestedValue(obj: unknown, path: string): unknown {
+  // 型安全性を失う + 現在は1箇所でしか使わない
+}
+
+// ✅ 良い例: 特化した型安全な関数
+function deserializeSettings(data: unknown): GlobalSettings | null {
+  // 型安全 + 明確な責任
+}
+```
+
+#### 過剰な抽象化のコスト
+
+- 型安全性の喪失（`as any` の増加）
+- テストの複雑化
+- 保守コストの増加
+- 実際には使われない「拡張性」
+
+**原則**: 3回目の重複が現れるまで汎用化しない（Three Strikes Rule）
 
 ## コードスタイル
 

--- a/src/utils/__tests__/storageSerializer.test.ts
+++ b/src/utils/__tests__/storageSerializer.test.ts
@@ -1,0 +1,161 @@
+import { describe, it, expect } from 'vitest';
+import { serializeSettings, deserializeSettings } from '../storageSerializer';
+import type { GlobalSettings } from '../../types';
+import { PROLIFERATOR_DATA, CONVEYOR_BELT_DATA, SORTER_DATA } from '../../types/settings';
+
+describe('storageSerializer', () => {
+  const mockSettings: GlobalSettings = {
+    proliferator: {
+      ...PROLIFERATOR_DATA.mk2,
+      mode: 'speed',
+    },
+    machineRank: {
+      Smelt: 'arc',
+      Assemble: 'mk2',
+      Chemical: 'standard',
+      Research: 'standard',
+      Refine: 'standard',
+      Particle: 'standard',
+    },
+    conveyorBelt: CONVEYOR_BELT_DATA.mk3,
+    sorter: SORTER_DATA.pile,
+    alternativeRecipes: new Map([
+      [1116, 1406],
+      [1109, 1106],
+      [1120, -1],
+    ]),
+    miningSpeedResearch: 150,
+    proliferatorMultiplier: { production: 1, speed: 1 },
+  };
+
+  describe('serializeSettings', () => {
+    it('should convert Map to Array', () => {
+      const serialized = serializeSettings(mockSettings);
+
+      expect(Array.isArray(serialized.alternativeRecipes)).toBe(true);
+      expect(serialized.alternativeRecipes).toEqual([
+        [1116, 1406],
+        [1109, 1106],
+        [1120, -1],
+      ]);
+    });
+
+    it('should preserve other settings', () => {
+      const serialized = serializeSettings(mockSettings);
+
+      expect(serialized.proliferator).toEqual(mockSettings.proliferator);
+      expect(serialized.machineRank).toEqual(mockSettings.machineRank);
+      expect(serialized.conveyorBelt).toEqual(mockSettings.conveyorBelt);
+      expect(serialized.sorter).toEqual(mockSettings.sorter);
+      expect(serialized.miningSpeedResearch).toBe(150);
+      expect(serialized.proliferatorMultiplier).toEqual({ production: 1, speed: 1 });
+    });
+
+    it('should be JSON serializable', () => {
+      const serialized = serializeSettings(mockSettings);
+      
+      // JSON.stringify でエラーが出ないことを確認
+      expect(() => JSON.stringify(serialized)).not.toThrow();
+      
+      // JSON roundtrip
+      const json = JSON.stringify(serialized);
+      const parsed = JSON.parse(json);
+      expect(parsed).toEqual(serialized);
+    });
+  });
+
+  describe('deserializeSettings', () => {
+    it('should convert Array back to Map', () => {
+      const serialized = serializeSettings(mockSettings);
+      const deserialized = deserializeSettings(serialized);
+
+      expect(deserialized).not.toBeNull();
+      expect(deserialized!.alternativeRecipes).toBeInstanceOf(Map);
+      expect(deserialized!.alternativeRecipes.get(1116)).toBe(1406);
+      expect(deserialized!.alternativeRecipes.get(1109)).toBe(1106);
+      expect(deserialized!.alternativeRecipes.get(1120)).toBe(-1);
+    });
+
+    it('should handle missing alternativeRecipes', () => {
+      const serialized = serializeSettings(mockSettings);
+      // @ts-expect-error: テストのため意図的に削除
+      delete serialized.alternativeRecipes;
+
+      const deserialized = deserializeSettings(serialized);
+
+      expect(deserialized).not.toBeNull();
+      expect(deserialized!.alternativeRecipes).toBeInstanceOf(Map);
+      expect(deserialized!.alternativeRecipes.size).toBe(0);
+    });
+
+    it('should handle missing stackCount in conveyorBelt', () => {
+      const serialized = serializeSettings(mockSettings);
+      // stackCount を削除
+      serialized.conveyorBelt = { 
+        tier: 'mk2', 
+        speed: 12, 
+        stackCount: undefined as unknown as number 
+      };
+
+      const deserialized = deserializeSettings(serialized);
+
+      expect(deserialized).not.toBeNull();
+      expect(deserialized!.conveyorBelt.stackCount).toBe(1); // デフォルト値
+      expect(deserialized!.conveyorBelt.tier).toBe('mk2');
+    });
+
+    it('should return null for invalid data', () => {
+      expect(deserializeSettings(null)).toBeNull();
+      expect(deserializeSettings(undefined)).toBeNull();
+      expect(deserializeSettings({})).toBeNull();
+      expect(deserializeSettings('invalid')).toBeNull();
+      expect(deserializeSettings(123)).toBeNull();
+    });
+
+    it('should return null for partially invalid data', () => {
+      const invalid = {
+        proliferator: { type: 'mk2' }, // OK
+        // machineRank: missing
+        conveyorBelt: { tier: 'mk3' },
+        sorter: { tier: 'pile' },
+        miningSpeedResearch: 100,
+        proliferatorMultiplier: { production: 1, speed: 1 },
+      };
+
+      expect(deserializeSettings(invalid)).toBeNull();
+    });
+
+    it('should roundtrip correctly', () => {
+      const serialized = serializeSettings(mockSettings);
+      const deserialized = deserializeSettings(serialized);
+
+      expect(deserialized).not.toBeNull();
+      
+      // Map の内容を比較
+      expect(deserialized!.alternativeRecipes.size).toBe(mockSettings.alternativeRecipes.size);
+      mockSettings.alternativeRecipes.forEach((value, key) => {
+        expect(deserialized!.alternativeRecipes.get(key)).toBe(value);
+      });
+
+      // 他のフィールドを比較
+      expect(deserialized!.proliferator).toEqual(mockSettings.proliferator);
+      expect(deserialized!.machineRank).toEqual(mockSettings.machineRank);
+      expect(deserialized!.conveyorBelt).toEqual(mockSettings.conveyorBelt);
+      expect(deserialized!.sorter).toEqual(mockSettings.sorter);
+      expect(deserialized!.miningSpeedResearch).toBe(mockSettings.miningSpeedResearch);
+      expect(deserialized!.proliferatorMultiplier).toEqual(mockSettings.proliferatorMultiplier);
+    });
+
+    it('should handle JSON roundtrip', () => {
+      const serialized = serializeSettings(mockSettings);
+      const json = JSON.stringify(serialized);
+      const parsed = JSON.parse(json);
+      const deserialized = deserializeSettings(parsed);
+
+      expect(deserialized).not.toBeNull();
+      expect(deserialized!.alternativeRecipes).toBeInstanceOf(Map);
+      expect(deserialized!.alternativeRecipes.size).toBe(3);
+    });
+  });
+});
+

--- a/src/utils/storageSerializer.ts
+++ b/src/utils/storageSerializer.ts
@@ -1,0 +1,98 @@
+/**
+ * localStorage用のシリアライズ・デシリアライズユーティリティ
+ * 
+ * Map型のシリアライズに特化した型安全な実装
+ */
+
+import type { GlobalSettings } from '../types';
+import { CONVEYOR_BELT_DATA } from '../types/settings';
+
+/**
+ * localStorage に保存される settings の中間形式
+ * Map は配列として保存される
+ */
+interface SerializedSettings {
+  proliferator: GlobalSettings['proliferator'];
+  machineRank: GlobalSettings['machineRank'];
+  conveyorBelt: GlobalSettings['conveyorBelt'];
+  sorter: GlobalSettings['sorter'];
+  alternativeRecipes: Array<[number, number]>; // Map → Array
+  miningSpeedResearch: GlobalSettings['miningSpeedResearch'];
+  proliferatorMultiplier: GlobalSettings['proliferatorMultiplier'];
+}
+
+/**
+ * GlobalSettings を localStorage 保存用にシリアライズ
+ */
+export function serializeSettings(settings: GlobalSettings): SerializedSettings {
+  return {
+    proliferator: settings.proliferator,
+    machineRank: settings.machineRank,
+    conveyorBelt: settings.conveyorBelt,
+    sorter: settings.sorter,
+    alternativeRecipes: Array.from(settings.alternativeRecipes.entries()),
+    miningSpeedResearch: settings.miningSpeedResearch,
+    proliferatorMultiplier: settings.proliferatorMultiplier,
+  };
+}
+
+/**
+ * localStorage から読み込んだデータを GlobalSettings にデシリアライズ
+ */
+export function deserializeSettings(serialized: unknown): GlobalSettings | null {
+  // 型ガード: 基本構造の検証
+  if (!isSerializedSettings(serialized)) {
+    return null;
+  }
+
+  // alternativeRecipes: 配列 → Map 変換
+  const alternativeRecipes = new Map<number, number>(
+    Array.isArray(serialized.alternativeRecipes) 
+      ? serialized.alternativeRecipes 
+      : []
+  );
+
+  // conveyorBelt: stackCount のフォールバック処理
+  let conveyorBelt = serialized.conveyorBelt;
+  if (typeof conveyorBelt?.stackCount !== 'number') {
+    const tier = (conveyorBelt?.tier || 'mk3') as keyof typeof CONVEYOR_BELT_DATA;
+    conveyorBelt = {
+      ...CONVEYOR_BELT_DATA[tier],
+      ...conveyorBelt,
+      stackCount: 1, // デフォルト値
+    };
+  }
+
+  return {
+    proliferator: serialized.proliferator,
+    machineRank: serialized.machineRank,
+    conveyorBelt,
+    sorter: serialized.sorter,
+    alternativeRecipes,
+    miningSpeedResearch: serialized.miningSpeedResearch,
+    proliferatorMultiplier: serialized.proliferatorMultiplier,
+  };
+}
+
+/**
+ * 型ガード: SerializedSettings かどうかを判定
+ */
+function isSerializedSettings(data: unknown): data is SerializedSettings {
+  if (typeof data !== 'object' || data === null) {
+    return false;
+  }
+
+  const obj = data as Record<string, unknown>;
+
+  // 必須フィールドの存在チェック（最小限）
+  return (
+    typeof obj.proliferator === 'object' &&
+    typeof obj.machineRank === 'object' &&
+    typeof obj.conveyorBelt === 'object' &&
+    typeof obj.sorter === 'object' &&
+    typeof obj.miningSpeedResearch === 'number' &&
+    typeof obj.proliferatorMultiplier === 'object'
+    // alternativeRecipes は配列 or undefined でもOK（デフォルト値を使う）
+  );
+}
+


### PR DESCRIPTION
Closes #40

## 変更内容

- 型安全な専用ユーティリティ関数を作成（storageSerializer.ts）
  - serializeSettings: GlobalSettings → JSON保存用形式
  - deserializeSettings: JSON → GlobalSettings
  - as any を一切使用しない型安全な実装

- settingsStore のリファクタリング
  - 複雑なシリアライズロジックを専用関数に移譲
  - エラーハンドリングを追加
  - コードの可読性向上

- YAGNI原則の明文化（coding.mdc）
  - Three Strikes Rule の追加
  - 過剰な抽象化の危険性を明記

## テスト

- 新規テスト: 10/10 passed
- 既存テスト: 877/877 passed
- Linter: No errors

## Issue #40 について

提案されていた汎用的な createMapStorage ミドルウェアは、
型安全性を犠牲にするため実装せず、代わりに特化した
型安全な関数で解決しました。

YAGNI原則に従い、現時点で必要な settingsStore のみに
対応し、3箇所目の重複が現れるまで汎用化しません。