### PR TITLE
feat: configure Dependabot to target develop branch with daily schedule

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,10 +4,10 @@ updates:
   - package-ecosystem: "npm"
     directory: "/"
     schedule:
-      interval: "weekly"
-      day: "monday"
+      interval: "daily"
       time: "09:00"
       timezone: "Asia/Tokyo"
+    target-branch: "develop"
     open-pull-requests-limit: 10
     labels:
       - "dependencies"
@@ -49,10 +49,10 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "weekly"
-      day: "monday"
+      interval: "daily"
       time: "09:00"
       timezone: "Asia/Tokyo"
+    target-branch: "develop"
     labels:
       - "dependencies"
       - "github-actions"


### PR DESCRIPTION
## 変更内容

- Dependabotのターゲットブランチをmainからdevelopに変更
- スケジュールを週次から日次（毎朝9時 JST）に変更
- npm依存関係とGitHub Actionsの両方に同じ設定を適用

## 設定詳細

- **ターゲットブランチ**: develop
- **スケジュール**: 毎日 09:00 (Asia/Tokyo)
- **対象**: npm依存関係 + GitHub Actions
- **グループ化**: React、Radix UI、開発依存関係など関連パッケージをまとめて更新

これにより、依存関係の更新がdevelopブランチに対して自動的にプルリクエストが作成されるようになります。