### PR TITLE
feat: allow dependabot/* branches to create PRs to develop

### DIFF
--- a/.github/workflows/develop.yaml
+++ b/.github/workflows/develop.yaml
@@ -13,9 +13,9 @@ jobs:
     steps:
       - name: Check:if PR is from feature or hotfix to develop branch
         run: |
-          if [ "${{ github.event.pull_request.base.ref }}" == "develop" ] && ([[ "${{ github.event.pull_request.head.ref }}" =~ ^feature/.* ]] || [[ "${{ github.event.pull_request.head.ref }}" =~ ^hotfix/.* ]]); then
-            echo "Pull request from feature or hotfix to develop branch"  
+          if [ "${{ github.event.pull_request.base.ref }}" == "develop" ] && ([[ "${{ github.event.pull_request.head.ref }}" =~ ^feature/.* ]] || [[ "${{ github.event.pull_request.head.ref }}" =~ ^hotfix/.* ]] || [[ "${{ github.event.pull_request.head.ref }}" =~ ^dependabot/.* ]]); then
+            echo "Pull request from feature, hotfix, or dependabot to develop branch"
           else
-            echo "Pull request not from feature or hotfix to develop branch, exiting with code 1"
+            echo "Pull request not from feature, hotfix, or dependabot to develop branch, exiting with code 1"
             exit 1
           fi


### PR DESCRIPTION
## 変更内容

GitHub Actions の develop ブランチ保護ルールを更新し、`dependabot/*` ブランチからの PR も許可するようにしました。

## 変更理由

Dependabot が依存関係の更新 PR を作成する際に、develop ブランチへの PR がブロックされないようにするため。

## 変更詳細

- `.github/workflows/develop.yaml` の条件式に `dependabot/*` パターンを追加
- エラーメッセージを更新して、許可されるブランチパターンを明記

## テスト

- [ ] develop ブランチへの PR が正常に作成できることを確認